### PR TITLE
Add multi-format image model server with preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # MTP
 
-This repository simulates a simple healthcare AI inference setup. A Flask server
-serves a small web interface where users can upload an image and choose a model
-for prediction. Models are downloaded locally via helper scripts so inference
-runs entirely offline once the assets are fetched.
+This repository simulates a lightweight healthcare AI inference service. A Flask
+server exposes REST endpoints and a small web UI where users can upload images
+and choose from multiple vision models. Models are downloaded locally so all
+inference runs offline once the assets are present.
+
+## Features
+
+* Keras, PyTorch and ONNX model formats handled through a unified interface
+* Auto image preprocessing (resize, normalization, color/EXIF handling)
+* Endpoints for health checks, model registry, single & batch prediction, and
+  simple request metrics
+* Basic web interface to upload an image and view predictions
 
 ## Setup
 
@@ -21,7 +29,7 @@ pip install -r requirements.txt
 python scripts/download_models.py
 ```
 
-The script retrieves several vision and NLP models and stores them under
+The script fetches or exports several vision models and stores them under
 `models/`. Downloads are skipped if the files already exist.
 
 ## Run smoke tests
@@ -39,16 +47,28 @@ working. Failures include a message suggesting you download the missing model.
 python inference_server.py
 ```
 
-The server hosts the UI at http://127.0.0.1:5000. Upload an image, pick a model,
-and view the predicted label and confidence.
+The server hosts the UI at http://127.0.0.1:5000. Upload an image, pick a model
+from the drop‑down (populated from `/models`), and view the predicted label and
+confidence.
+
+### API Endpoints
+
+| Method | Path             | Description                              |
+| ------ | ---------------- | ---------------------------------------- |
+| GET    | `/health`        | Basic health check                       |
+| GET    | `/models`        | List available models                    |
+| POST   | `/predict`       | Predict for a single uploaded image      |
+| POST   | `/batch_predict` | Predict for multiple images in one call  |
+| GET    | `/metrics`       | Simple request counters per model        |
 
 ## Models
 
-| Key | Description | Expected Input |
-| --- | ----------- | -------------- |
-| `mnist_digits` | CNN trained on MNIST digits | 28×28 grayscale digit |
-| `fashion_mnist` | Fashion-MNIST classifier | 28×28 grayscale fashion item |
-| `resnet18_imagenet` | Torchvision ResNet18 | RGB image; resized to 224×224 |
+| Key                  | Description                       | Format   |
+| -------------------- | --------------------------------- | -------- |
+| `mnist_digits`       | CNN trained on MNIST digits       | Keras    |
+| `fashion_mnist`      | Fashion-MNIST classifier          | Keras    |
+| `resnet18_imagenet`  | ResNet18 ImageNet classifier      | PyTorch  |
+| `mobilenet_v3_small` | MobileNetV3 Small ImageNet model  | ONNX     |
 
 ## Repository tree
 
@@ -64,6 +84,9 @@ MTP/
 ├── templates/
 │   └── index.html
 ├── inference_server.py
+├── model_loader.py
+├── model_registry.py
+├── preprocess.py
 ├── requirements.txt
 ├── README.md
 └── .gitignore

--- a/inference_server.py
+++ b/inference_server.py
@@ -1,53 +1,17 @@
-"""Flask inference server with simple web UI."""
+"""Flask inference server with multi-model support and preprocessing."""
 from __future__ import annotations
 
-from pathlib import Path
-
+from collections import Counter
 import numpy as np
-import tensorflow as tf
-import torch
 from flask import Flask, jsonify, render_template, request
 from flask_cors import CORS
-from PIL import Image
-from torchvision import transforms
-from torchvision.models import ResNet18_Weights, resnet18
+
+from model_registry import MODEL_SPECS, get_model, list_models
+from preprocess import prepare_image
 
 app = Flask(__name__)
 CORS(app)
-
-MODEL_DIR = Path(__file__).resolve().parent / "models"
-FASHION_LABELS = [
-    "T-shirt/top",
-    "Trouser",
-    "Pullover",
-    "Dress",
-    "Coat",
-    "Sandal",
-    "Shirt",
-    "Sneaker",
-    "Bag",
-    "Ankle boot",
-]
-
-_keras_cache: dict[str, tf.keras.Model] = {}
-_resnet_cache: dict[str, object] = {}
-
-
-def load_keras_model(key: str, filename: str) -> tf.keras.Model:
-    if key not in _keras_cache:
-        model_path = MODEL_DIR / filename
-        _keras_cache[key] = tf.keras.models.load_model(model_path)
-    return _keras_cache[key]
-
-
-def load_resnet18() -> tuple[torch.nn.Module, ResNet18_Weights]:
-    if not _resnet_cache:
-        weights = ResNet18_Weights.DEFAULT
-        model = resnet18(weights=weights)
-        model.eval()
-        _resnet_cache["model"] = model
-        _resnet_cache["weights"] = weights
-    return _resnet_cache["model"], _resnet_cache["weights"]
+metrics = Counter()
 
 
 @app.get("/")
@@ -55,56 +19,69 @@ def index() -> str:
     return render_template("index.html")
 
 
-@app.post("/infer")
-def infer():
+@app.get("/health")
+def health() -> tuple[str, int]:
+    return jsonify({"status": "ok"})
+
+
+@app.get("/models")
+def models_endpoint():
+    return jsonify({"models": list_models()})
+
+
+@app.post("/predict")
+def predict():
     if "file" not in request.files:
         return jsonify({"error": "missing file"}), 400
     model_key = request.form.get("model_key")
-    if model_key not in {"mnist_digits", "fashion_mnist", "resnet18_imagenet"}:
+    if model_key not in MODEL_SPECS:
         return jsonify({"error": "invalid model_key"}), 400
-
-    file = request.files["file"]
-    try:
-        if model_key in {"mnist_digits", "fashion_mnist"}:
-            img = Image.open(file.stream).convert("L").resize((28, 28))
-            arr = np.array(img, dtype="float32") / 255.0
-            arr = arr.reshape(1, 28, 28, 1)
-            model = load_keras_model(
-                model_key,
-                "mnist_digits.h5" if model_key == "mnist_digits" else "fashion_mnist.h5",
-            )
-            preds = model.predict(arr)
-            idx = int(np.argmax(preds))
-            conf = float(np.max(preds))
-            label = str(idx) if model_key == "mnist_digits" else FASHION_LABELS[idx]
-        else:
-            model, weights = load_resnet18()
-            img = Image.open(file.stream).convert("RGB")
-            preprocess = transforms.Compose(
-                [
-                    transforms.Resize((224, 224)),
-                    transforms.ToTensor(),
-                    transforms.Normalize(mean=weights.meta["mean"], std=weights.meta["std"]),
-                ]
-            )
-            tensor = preprocess(img).unsqueeze(0)
-            with torch.no_grad():
-                outputs = model(tensor)
-                probs = torch.softmax(outputs, dim=1)[0]
-            idx = int(torch.argmax(probs))
-            conf = float(probs[idx])
-            label = weights.meta["categories"][idx]
-        return jsonify(
-            {
-                "prediction_index": idx,
-                "prediction_label": label,
-                "confidence": conf,
-                "model_used": model_key,
-            }
-        )
-    except Exception as exc:  # noqa: BLE001
-        return jsonify({"error": str(exc)}), 500
+    spec = MODEL_SPECS[model_key]
+    arr = prepare_image(request.files["file"].stream, spec)
+    model = get_model(model_key)
+    preds = model.predict(arr)[0]
+    idx = int(np.argmax(preds))
+    conf = float(np.max(preds))
+    label = spec.labels[idx] if spec.labels and idx < len(spec.labels) else str(idx)
+    metrics[model_key] += 1
+    return jsonify(
+        {
+            "prediction_index": idx,
+            "prediction_label": label,
+            "confidence": conf,
+            "model_used": model_key,
+        }
+    )
 
 
-if __name__ == "__main__":
+@app.post("/batch_predict")
+def batch_predict():
+    files = request.files.getlist("files")
+    model_key = request.form.get("model_key")
+    if not files:
+        return jsonify({"error": "missing files"}), 400
+    if model_key not in MODEL_SPECS:
+        return jsonify({"error": "invalid model_key"}), 400
+    spec = MODEL_SPECS[model_key]
+    arrs = [prepare_image(f.stream, spec) for f in files]
+    batch = np.concatenate(arrs, axis=0)
+    model = get_model(model_key)
+    outputs = model.predict(batch)
+    results = []
+    for preds in outputs:
+        idx = int(np.argmax(preds))
+        conf = float(np.max(preds))
+        label = spec.labels[idx] if spec.labels and idx < len(spec.labels) else str(idx)
+        results.append({"prediction_index": idx, "prediction_label": label, "confidence": conf})
+    metrics[model_key] += len(files)
+    return jsonify({"model_used": model_key, "predictions": results})
+
+
+@app.get("/metrics")
+def metrics_endpoint():
+    lines = [f"requests_total{{model='{k}'}} {v}" for k, v in metrics.items()]
+    return "\n".join(lines), 200, {"Content-Type": "text/plain"}
+
+
+if __name__ == "__main__":  # pragma: no cover
     app.run(debug=True)

--- a/model_loader.py
+++ b/model_loader.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import onnxruntime as ort
+import tensorflow as tf
+import torch
+
+
+@dataclass
+class ModelSpec:
+    """Description of a model that can be served."""
+
+    key: str
+    path: Path
+    format: str  # keras | torch | onnx
+    description: str
+    input_size: tuple[int, int]
+    mode: str
+    mean: List[float]
+    std: List[float]
+    labels: List[str]
+
+
+class BaseModel:
+    """Simple wrapper around a loaded model with a unified predict method."""
+
+    def __init__(self, spec: ModelSpec) -> None:
+        self.spec = spec
+
+    def predict(self, batch: np.ndarray) -> np.ndarray:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class KerasModel(BaseModel):
+    def __init__(self, spec: ModelSpec) -> None:
+        super().__init__(spec)
+        self.model = tf.keras.models.load_model(spec.path)
+
+    def predict(self, batch: np.ndarray) -> np.ndarray:
+        return self.model.predict(batch)
+
+
+class TorchModel(BaseModel):
+    def __init__(self, spec: ModelSpec) -> None:
+        super().__init__(spec)
+        self.model = torch.load(spec.path, map_location="cpu")
+        self.model.eval()
+
+    def predict(self, batch: np.ndarray) -> np.ndarray:
+        with torch.no_grad():
+            tensor = torch.from_numpy(batch)
+            outputs = self.model(tensor)
+            return outputs.numpy() if isinstance(outputs, torch.Tensor) else outputs
+
+
+class ONNXModel(BaseModel):
+    def __init__(self, spec: ModelSpec) -> None:
+        super().__init__(spec)
+        self.session = ort.InferenceSession(str(spec.path), providers=["CPUExecutionProvider"])
+
+    def predict(self, batch: np.ndarray) -> np.ndarray:
+        inputs = {self.session.get_inputs()[0].name: batch}
+        return self.session.run(None, inputs)[0]

--- a/model_registry.py
+++ b/model_registry.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from model_loader import BaseModel, KerasModel, ModelSpec, ONNXModel, TorchModel
+
+MODEL_DIR = Path(__file__).resolve().parent / "models"
+
+# ImageNet labels used for both PyTorch and ONNX models
+_IMAGENET_LABELS: List[str]
+labels_file = MODEL_DIR / "imagenet_labels.txt"
+if labels_file.exists():
+    _IMAGENET_LABELS = labels_file.read_text().splitlines()
+else:  # Fallback to empty list
+    _IMAGENET_LABELS = []
+
+MODEL_SPECS: Dict[str, ModelSpec] = {
+    "mnist_digits": ModelSpec(
+        key="mnist_digits",
+        path=MODEL_DIR / "mnist_digits.h5",
+        format="keras",
+        description="MNIST digit classifier (Keras)",
+        input_size=(28, 28),
+        mode="L",
+        mean=[0.0],
+        std=[1.0],
+        labels=[str(i) for i in range(10)],
+    ),
+    "fashion_mnist": ModelSpec(
+        key="fashion_mnist",
+        path=MODEL_DIR / "fashion_mnist.h5",
+        format="keras",
+        description="Fashion-MNIST classifier (Keras)",
+        input_size=(28, 28),
+        mode="L",
+        mean=[0.0],
+        std=[1.0],
+        labels=[
+            "T-shirt/top",
+            "Trouser",
+            "Pullover",
+            "Dress",
+            "Coat",
+            "Sandal",
+            "Shirt",
+            "Sneaker",
+            "Bag",
+            "Ankle boot",
+        ],
+    ),
+    "resnet18_imagenet": ModelSpec(
+        key="resnet18_imagenet",
+        path=MODEL_DIR / "resnet18.pt",
+        format="torch",
+        description="ResNet18 ImageNet (PyTorch)",
+        input_size=(224, 224),
+        mode="RGB",
+        mean=[0.485, 0.456, 0.406],
+        std=[0.229, 0.224, 0.225],
+        labels=_IMAGENET_LABELS,
+    ),
+    "mobilenet_v3_small": ModelSpec(
+        key="mobilenet_v3_small",
+        path=MODEL_DIR / "mobilenet_v3_small.onnx",
+        format="onnx",
+        description="MobileNetV3 Small (ONNX)",
+        input_size=(224, 224),
+        mode="RGB",
+        mean=[0.485, 0.456, 0.406],
+        std=[0.229, 0.224, 0.225],
+        labels=_IMAGENET_LABELS,
+    ),
+}
+
+_model_cache: Dict[str, BaseModel] = {}
+
+
+def list_models() -> List[dict]:
+    """Return lightweight info about available models."""
+    return [
+        {"key": spec.key, "description": spec.description, "format": spec.format}
+        for spec in MODEL_SPECS.values()
+    ]
+
+
+def get_model(key: str) -> BaseModel:
+    """Return a loaded model, loading it on first use."""
+    if key not in MODEL_SPECS:
+        raise KeyError(key)
+    if key not in _model_cache:
+        spec = MODEL_SPECS[key]
+        if spec.format == "keras":
+            _model_cache[key] = KerasModel(spec)
+        elif spec.format == "torch":
+            _model_cache[key] = TorchModel(spec)
+        elif spec.format == "onnx":
+            _model_cache[key] = ONNXModel(spec)
+        else:  # pragma: no cover - defensive
+            raise ValueError(f"Unsupported format: {spec.format}")
+    return _model_cache[key]

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from PIL import Image, ImageOps
+import numpy as np
+
+from model_loader import ModelSpec
+
+
+def prepare_image(file, spec: ModelSpec) -> np.ndarray:
+    """Load an image file and transform it into a model-ready numpy array."""
+    img = Image.open(file).convert(spec.mode)
+    img = ImageOps.exif_transpose(img)
+    img = ImageOps.fit(img, spec.input_size, method=Image.Resampling.BILINEAR)
+    arr = np.asarray(img).astype("float32") / 255.0
+    if spec.mode == "L":
+        arr = arr[..., None]
+    if spec.format in {"torch", "onnx"}:
+        arr = arr.transpose(2, 0, 1)
+        for c in range(arr.shape[0]):
+            arr[c] = (arr[c] - spec.mean[c]) / spec.std[c]
+    else:  # keras models
+        arr = (arr - spec.mean[0]) / spec.std[0]
+    return arr[None, ...]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ flask-cors
 tensorflow>=2.13
 torch>=2.2
 torchvision>=0.17
-transformers>=4.40
+onnxruntime>=1.17
 huggingface-hub>=0.23
+transformers>=4.40
 tqdm
 requests
 numpy

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import numpy as np
 import tensorflow as tf
 import torch
-from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer
+
+try:  # optional dependency
+    import onnxruntime as ort
+except Exception:  # noqa: BLE001
+    ort = None
 
 MODEL_DIR = Path(__file__).resolve().parent.parent / "models"
 
@@ -27,41 +31,44 @@ def test_keras(model_file: str, label: str) -> None:
         print(f"❌ {label} failed: {exc}")
 
 
-def test_gpt2() -> None:
-    model_dir = MODEL_DIR / "gpt2"
-    if not model_dir.exists():
-        print("❌ gpt2 missing; run scripts/download_models.py")
+def test_torch(model_file: str, label: str) -> None:
+    path = MODEL_DIR / model_file
+    if not path.exists():
+        print(f"❌ {model_file} missing; run scripts/download_models.py")
         return
     try:
-        tokenizer = AutoTokenizer.from_pretrained(model_dir)
-        model = AutoModelForCausalLM.from_pretrained(model_dir)
-        prompt = "Patient reports mild chest pain. Recommended next step:"
-        inputs = tokenizer.encode(prompt, return_tensors="pt")
-        output_ids = model.generate(inputs, max_new_tokens=30)
-        text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
-        print(f"✅ GPT-2 output: {text}")
-    except Exception as exc:  # noqa: BLE001
-        print(f"❌ GPT-2 failed: {exc}")
-
-
-def test_distilbert() -> None:
-    model_dir = MODEL_DIR / "distilbert-sst2"
-    if not model_dir.exists():
-        print("❌ distilbert-sst2 missing; run scripts/download_models.py")
-        return
-    try:
-        tokenizer = AutoTokenizer.from_pretrained(model_dir)
-        model = AutoModelForSequenceClassification.from_pretrained(model_dir)
-        text = "The medication worked surprisingly well and I feel better."
-        inputs = tokenizer(text, return_tensors="pt")
-        outputs = model(**inputs)
-        probs = torch.softmax(outputs.logits, dim=-1)[0]
+        bundle = torch.load(path, map_location="cpu")
+        model = bundle["model"] if isinstance(bundle, dict) and "model" in bundle else bundle
+        model.eval()
+        dummy = torch.randn(1, 3, 224, 224)
+        with torch.no_grad():
+            out = model(dummy)
+            probs = torch.softmax(out, dim=1)[0]
         idx = int(torch.argmax(probs))
-        score = float(probs[idx])
-        label = model.config.id2label.get(idx, str(idx))
-        print(f"✅ DistilBERT sentiment: {label} (score {score:.4f})")
+        conf = float(probs[idx])
+        print(f"✅ {label}: class {idx} (confidence {conf:.4f})")
     except Exception as exc:  # noqa: BLE001
-        print(f"❌ DistilBERT failed: {exc}")
+        print(f"❌ {label} failed: {exc}")
+
+
+def test_onnx(model_file: str, label: str) -> None:
+    if ort is None:
+        print("⚠️ onnxruntime not installed; skipping ONNX tests")
+        return
+    path = MODEL_DIR / model_file
+    if not path.exists():
+        print(f"❌ {model_file} missing; run scripts/download_models.py")
+        return
+    try:
+        session = ort.InferenceSession(str(path), providers=["CPUExecutionProvider"])
+        dummy = np.random.randn(1, 3, 224, 224).astype("float32")
+        inputs = {session.get_inputs()[0].name: dummy}
+        outputs = session.run(None, inputs)[0]
+        idx = int(np.argmax(outputs[0]))
+        conf = float(np.max(outputs[0]))
+        print(f"✅ {label}: class {idx} (confidence {conf:.4f})")
+    except Exception as exc:  # noqa: BLE001
+        print(f"❌ {label} failed: {exc}")
 
 
 def main() -> None:
@@ -70,8 +77,8 @@ def main() -> None:
         return
     test_keras("mnist_digits.h5", "MNIST digits")
     test_keras("fashion_mnist.h5", "Fashion-MNIST")
-    test_gpt2()
-    test_distilbert()
+    test_torch("resnet18.pt", "ResNet18 ImageNet")
+    test_onnx("mobilenet_v3_small.onnx", "MobileNetV3 Small")
 
 
 if __name__ == "__main__":

--- a/static/app.js
+++ b/static/app.js
@@ -1,3 +1,18 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const modelSelect = document.getElementById('modelSelect');
+  try {
+    const resp = await axios.get('/models');
+    resp.data.models.forEach((m) => {
+      const opt = document.createElement('option');
+      opt.value = m.key;
+      opt.textContent = m.description;
+      modelSelect.appendChild(opt);
+    });
+  } catch (err) {
+    console.error('Failed to load model registry', err);
+  }
+});
+
 document.getElementById('uploadForm').addEventListener('submit', async (e) => {
   e.preventDefault();
   const fileInput = document.getElementById('fileInput');
@@ -25,7 +40,7 @@ document.getElementById('uploadForm').addEventListener('submit', async (e) => {
   submitBtn.textContent = 'Loading...';
 
   try {
-    const resp = await axios.post('/infer', formData);
+    const resp = await axios.post('/predict', formData);
     const data = resp.data;
     predLabel.textContent = `${data.prediction_label}`;
     predConf.textContent = data.confidence.toFixed(4);

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,11 +15,7 @@
           <input class="form-control" type="file" id="fileInput" accept="image/*" required>
         </div>
         <div class="mb-3">
-          <select class="form-select" id="modelSelect">
-            <option value="mnist_digits">MNIST Digits</option>
-            <option value="fashion_mnist">Fashion-MNIST</option>
-            <option value="resnet18_imagenet">ResNet18 ImageNet</option>
-          </select>
+          <select class="form-select" id="modelSelect"></select>
         </div>
         <button class="btn btn-primary" type="submit">Run Inference</button>
       </form>


### PR DESCRIPTION
## Summary
- introduce unified model loaders for Keras, PyTorch and ONNX with a registry
- add preprocessing pipeline and new REST endpoints with metrics and batch inference
- expand download and smoke-test scripts to handle new models and optional dependencies

## Testing
- `python scripts/test_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7652a7a2c8331ab9be31be00c75a3